### PR TITLE
fix(ai-chat): toolRenderers 通道对齐、1→N 派生气泡编辑丢内容

### DIFF
--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -330,7 +330,7 @@ const toolRenderers = { generate_quiz: markRaw(QuizCard) };
 </template>
 ```
 
-自定义渲染器拿到完整 `tool_use` 块（`input`/`output`/`state`）+ `info` + `onBlockAction` + `onBlockIntent`，与内置块渲染器的契约完全一致（见「块交互的两条通道」）：
+自定义渲染器拿到完整 `tool_use` 块（`input`/`output`/`state`）+ `info` + `onBlockAction` + `onBlockIntent`，与内置块渲染器的契约完全一致（见「块交互的两条通道」）——**事件与块插槽两条通道同样对等**：委托目标 emit 的 `keep-mounted-change`（浮层开合，让虚拟列表保持宿主行挂载）与 `typing-complete` 会逐层上抛，穿透下来的块插槽也原样转交。即同一个组件注册为 `toolRenderers` 还是 `blockRenderers`，拿到的能力完全一样。
 
 - 学生作答等**改自己数据**的交互经 `onBlockAction({ blockId, type, patch })` 回写——`AiChat` 内部先 `updateBlock` 命中才向上 emit `block-action`；
 - **需要宿主处置**的交互（工具审批放行、点提交后带 `Last-Event-ID` 续流等）经 `onBlockIntent({ blockId, type, payload })` 上抛到 `AiChat` 的 `block-intent`，组件库不据此改动任何数据。配合 `state: 'awaiting-approval'` 即可实现工具调用的人工审批卡。
@@ -641,7 +641,14 @@ const toolbarItems = [
 | `v-model:tree` | 完整对话树（含所有分支版本），`ExportedTree` | 需要保留「重新生成 / 编辑重发」产生的兄弟版本 |
 | `v-model:messages` | 仅当前激活路径的扁平消息数组 | 不需要分支历史的简单场景 |
 
-同时绑定两者时以 `tree` 为准（`messages` 退化为只读镜像输出，不再反向导入）。
+同时绑定两者时以 `tree` 为准（`messages` 退化为只读镜像输出，不再反向导入）。走哪条通道由「是否绑定了 `tree`」自动推断（读编译后的 vnode props，`v-model:tree` 与单向 `:tree` 都能识别），常规模板写法无需干预。
+
+若推断失准（用 `h()` / JSX 手写 vnode、或经高阶组件 `v-bind="$attrs"` 中转），用 `treeMode` 显式声明：
+
+```vue
+<!-- 强制走 tree 通道；:tree-mode="false" 则强制走 messages 通道 -->
+<AiChat :tree="tree" :tree-mode="true" :request="request" @update:tree="save" />
+```
 
 最省事的接法是配 `useConversations`，它已经处理好下面全部细节：
 

--- a/packages/ai-chat/__test__/AiChat.subBubbleActions.test.ts
+++ b/packages/ai-chat/__test__/AiChat.subBubbleActions.test.ts
@@ -1,0 +1,130 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import AiChat from '../src/components/AiChat.vue';
+import type { ChatMessage, ExportedTree } from '../src/types';
+import { genBlockId } from '../src/utils/helpers';
+
+vi.mock('virtua/vue', () => ({
+  Virtualizer: {
+    name: 'Virtualizer',
+    props: ['data', 'keepMounted'],
+    setup(props: any, { slots }: any) {
+      return () => (props.data as unknown[]).map((item, i) => slots.default?.({ item, index: i }));
+    },
+  },
+}));
+
+const idleRequest = vi.fn(
+  async () =>
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        c.close();
+      },
+    }),
+);
+
+/** 把含多个 text 块的消息按块拆成多个气泡（1→N），user / ai 一视同仁 */
+const splitByBlock = (m: ChatMessage): ChatMessage | ChatMessage[] =>
+  m.content.length > 1 ? m.content.map((b) => ({ ...m, content: [b] })) : m;
+
+const twoBlockUser: ChatMessage = {
+  id: 'u1',
+  role: 'user',
+  status: 'success',
+  content: [
+    { id: genBlockId(), type: 'text', text: '第一段' },
+    { id: genBlockId(), type: 'text', text: '第二段' },
+  ],
+};
+
+/**
+ * Bug 防回归：1→N 的「仅末子气泡显示操作条」去重此前只写在 AI 分支里，user 分支先一步
+ * return 掉了。于是被拆分的用户消息每个子气泡都挂编辑按钮，而 useChat.onEdit 会按
+ * resolveParentId 解析回父消息、把父消息的全部 text 块塌成该子气泡那一段——用非首个子气泡
+ * 编辑再保存会静默丢掉其余段落。去重须对所有角色一致（与 branchMap 同规则）。
+ */
+describe('AiChat — 1→N 拆分时的操作条去重', () => {
+  it('被拆分的用户消息只有末子气泡挂操作条', async () => {
+    const w = mount(AiChat, {
+      props: { request: idleRequest, parser: splitByBlock, defaultMessages: [twoBlockUser] },
+    });
+    await flushPromises();
+
+    const bubbles = w.findAll('.aix-bubble--end');
+    expect(bubbles).toHaveLength(2); // 确认确实拆成了两个气泡
+    expect(bubbles[0]!.findAll('.aix-bubble-actions__btn')).toHaveLength(0);
+    expect(
+      bubbles[1]!.findAll('.aix-bubble-actions__btn').map((b) => b.attributes('aria-label')),
+    ).toEqual(['复制', '编辑']);
+  });
+
+  it('未拆分的用户消息操作条不受影响', async () => {
+    const w = mount(AiChat, {
+      props: {
+        request: idleRequest,
+        parser: splitByBlock,
+        defaultMessages: [
+          {
+            id: 'u1',
+            role: 'user',
+            status: 'success',
+            content: [{ id: 'b', type: 'text', text: '只有一段' }],
+          },
+        ],
+      },
+    });
+    await flushPromises();
+
+    expect(
+      w
+        .find('.aix-bubble--end')
+        .findAll('.aix-bubble-actions__btn')
+        .map((b) => b.attributes('aria-label')),
+    ).toEqual(['复制', '编辑']);
+  });
+});
+
+/**
+ * treeMode 逃生口：isTreeBound 默认靠编译后 vnode props 探测，h()/JSX 手写或经高阶组件
+ * $attrs 中转时可能失准。显式声明须优先于探测，且**未传时不得被 Vue 的 boolean casting
+ * 转成 false**（那会把自动推断整个短路掉，绑了 v-model:tree 也不生效）。
+ */
+describe('AiChat — treeMode 显式声明', () => {
+  it('未传 treeMode 时 v-model:tree 的自动推断仍生效', async () => {
+    const w = mount(AiChat, {
+      props: {
+        request: idleRequest,
+        tree: { nodes: [], headId: '__root__' } as ExportedTree,
+        'onUpdate:tree': () => {},
+      },
+    });
+    await w.find('textarea').setValue('问题');
+    await w.find('textarea').trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+    // 绑了 tree ⇒ 结构变化会导出回父
+    expect(w.emitted('update:tree')).toBeTruthy();
+  });
+
+  it('treeMode=false 可显式关闭 tree 通道（即便绑了 v-model:tree）', async () => {
+    const w = mount(AiChat, {
+      props: {
+        request: idleRequest,
+        treeMode: false,
+        tree: { nodes: [], headId: '__root__' } as ExportedTree,
+        'onUpdate:tree': () => {},
+      },
+    });
+    await w.find('textarea').setValue('问题');
+    await w.find('textarea').trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+    expect(w.emitted('update:tree')).toBeUndefined();
+  });
+
+  it('treeMode=true 可在探测失准时显式开启', async () => {
+    const w = mount(AiChat, { props: { request: idleRequest, treeMode: true } });
+    await w.find('textarea').setValue('问题');
+    await w.find('textarea').trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+    expect(w.emitted('update:tree')).toBeTruthy();
+  });
+});

--- a/packages/ai-chat/__test__/ToolUseBlock.delegate.test.ts
+++ b/packages/ai-chat/__test__/ToolUseBlock.delegate.test.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import Bubble from '../src/components/Bubble.vue';
+import type { ContentBlock } from '../src/types';
+
+/**
+ * Bug 防回归：`toolRenderers` 与 `blockRenderers` 必须是**能力对等**的两张注册表。
+ *
+ * Bubble 把 `@typing-complete` / `@keep-mounted-change` 与块插槽直接挂在「块渲染器」上；
+ * 对 tool_use 而言那个组件是内置 ToolUseBlock 而非委托目标，而它 inheritAttrs:false，
+ * 不显式 v-bind="$attrs" + 转发 slot 就会把这两条通道整个吃掉——自定义工具卡里的 Teleport
+ * 浮层（同内置 ImageBlock 的图片预览）因此拿不到 keepMounted，虚拟列表回收宿主行时会连同
+ * 打开状态一起销毁。
+ */
+
+/** 既上抛浮层开合、又消费一个块插槽的自定义渲染器（两条通道各测一次） */
+const PanelRenderer = defineComponent({
+  name: 'PanelRenderer',
+  props: { block: { type: Object, required: true } },
+  emits: ['keep-mounted-change', 'typing-complete'],
+  setup(_props, { emit, slots }) {
+    return () =>
+      h('div', [
+        h('button', { class: 'open', onClick: () => emit('keep-mounted-change', true) }, 'open'),
+        h('span', { class: 'slot-host' }, slots.extra?.({ from: 'renderer' })),
+      ]);
+  },
+});
+
+const toolBlock: ContentBlock = {
+  id: 'b1',
+  type: 'tool_use',
+  toolCallId: 'c1',
+  toolName: 'my_tool',
+  state: 'output-available',
+};
+
+describe('ToolUseBlock — 委托自定义工具渲染器的通道透传', () => {
+  it('委托目标上抛的 keep-mounted-change 逐层到达 Bubble（与 blockRenderers 等价）', async () => {
+    const w = mount(Bubble, {
+      props: { itemKey: 'm1', content: [toolBlock], toolRenderers: { my_tool: PanelRenderer } },
+    });
+    await w.find('button.open').trigger('click');
+    await nextTick();
+    expect(w.emitted('keep-mounted-change')).toEqual([[{ messageKey: 'm1', active: true }]]);
+  });
+
+  it('对照组：同一渲染器注册为 blockRenderers 时行为一致', async () => {
+    const w = mount(Bubble, {
+      props: {
+        itemKey: 'm1',
+        content: [{ id: 'b1', type: 'custom_x' } as unknown as ContentBlock],
+        blockRenderers: { custom_x: PanelRenderer },
+      },
+    });
+    await w.find('button.open').trigger('click');
+    await nextTick();
+    expect(w.emitted('keep-mounted-change')).toEqual([[{ messageKey: 'm1', active: true }]]);
+  });
+
+  it('块插槽穿透同样到达委托目标', () => {
+    const w = mount(Bubble, {
+      props: { itemKey: 'm1', content: [toolBlock], toolRenderers: { my_tool: PanelRenderer } },
+      slots: { extra: '透传成功' },
+    });
+    expect(w.find('.slot-host').text()).toBe('透传成功');
+  });
+
+  it('未命中 toolRenderers 时仍走内置折叠卡片（默认路径不受透传改动影响）', () => {
+    const w = mount(Bubble, {
+      props: { itemKey: 'm1', content: [toolBlock], toolRenderers: { other_tool: PanelRenderer } },
+    });
+    expect(w.find('.aix-tool-use').exists()).toBe(true);
+    expect(w.text()).toContain('my_tool');
+  });
+});

--- a/packages/ai-chat/__test__/useChat.derivedId.test.ts
+++ b/packages/ai-chat/__test__/useChat.derivedId.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useChat } from '../src/composables/useChat';
+import type { ChatMessage } from '../src/types';
+import { genBlockId } from '../src/utils/helpers';
+
+const emptyRequest = async () =>
+  new ReadableStream<Uint8Array>({
+    start(c) {
+      c.close();
+    },
+  });
+
+/** 把含多个 text 块的消息按块拆成多个气泡（1→N） */
+const splitByBlock = (m: ChatMessage): ChatMessage | ChatMessage[] =>
+  m.content.length > 1 ? m.content.map((b) => ({ ...m, content: [b] })) : m;
+
+const twoBlockUser = (id: string): ChatMessage => ({
+  id,
+  role: 'user',
+  status: 'success',
+  content: [
+    { id: genBlockId(), type: 'text', text: '第一段' },
+    { id: genBlockId(), type: 'text', text: '第二段' },
+  ],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Bug 防回归：onEdit 的改写语义是「把父消息的**全部** text 块合并为单个 text 块」，
+ * 而 parser 1→N 的派生气泡只持有父消息的一个切片。用派生气泡 id 发起编辑会把父消息塌成
+ * 那一段，其余段落静默消失（且 onEdit 返回 true，上层照常 emit 'edit' 误导业务持久化）。
+ * AiChat 侧已按 __sub 只给末子气泡挂操作条，但命令式调用绕得过 UI，故不变量收在 useChat。
+ */
+describe('useChat — 派生气泡 id 的编辑守卫', () => {
+  it('用非首个派生气泡 id 编辑被拒绝，父消息零改动', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chat = useChat({
+      request: emptyRequest,
+      parser: splitByBlock,
+      defaultMessages: [twoBlockUser('u1')],
+    });
+
+    const bubbles = chat.parsedMessages.value;
+    expect(bubbles.map((b) => b.id)).toEqual(['u1', 'u1__1']);
+
+    expect(await chat.onEdit('u1__1', '第二段改')).toBe(false);
+    // 消息树纹丝不动：未新增兄弟分支、未丢块
+    expect(chat.messages.value).toHaveLength(1);
+    expect(chat.messages.value[0]!.content.map((b) => (b as { text: string }).text)).toEqual([
+      '第一段',
+      '第二段',
+    ]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('派生气泡 id'));
+  });
+
+  it('首个子气泡复用父 id，照常受理（不误伤 1→N 的合法入口）', async () => {
+    const chat = useChat({
+      request: emptyRequest,
+      parser: splitByBlock,
+      defaultMessages: [twoBlockUser('u1')],
+    });
+    expect(await chat.onEdit('u1', '整条改写')).toBe(true);
+    // 新兄弟分支：文本块合并为单块，非文本块无（本例全为 text）
+    const edited = chat.messages.value[0]!;
+    expect(edited.content.map((b) => (b as { text: string }).text)).toEqual(['整条改写']);
+  });
+
+  it('1→1 parser 与无 parser 场景不受守卫影响', async () => {
+    const chat = useChat({
+      request: emptyRequest,
+      // 1→1：改写形状但 id 由 useChat 接管复用父 id
+      parser: (m) => ({ ...m, id: 'parser-改过的id' }),
+      defaultMessages: [twoBlockUser('u1')],
+    });
+    expect(await chat.onEdit('u1', 'x')).toBe(true);
+  });
+});
+
+describe('useChat — 派生 id 与真实消息 id 冲突告警', () => {
+  it('真实消息 id 撞上派生 id 形态时告警一次', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chat = useChat({
+      request: emptyRequest,
+      parser: splitByBlock,
+      // u1 会派生出 `u1__1`，而列表里恰好另有一条真实消息就叫 `u1__1`
+      defaultMessages: [
+        twoBlockUser('u1'),
+        { id: 'u1__1', role: 'user', status: 'success', content: [] },
+      ],
+    });
+
+    // 触发求值
+    void chat.parsedMessages.value;
+    void chat.parsedMessages.value;
+
+    const hits = warn.mock.calls.filter((c) => String(c[0]).includes('与一条真实消息 id 冲突'));
+    expect(hits).toHaveLength(1);
+  });
+
+  it('无冲突时不告警', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chat = useChat({
+      request: emptyRequest,
+      parser: splitByBlock,
+      defaultMessages: [twoBlockUser('u1')],
+    });
+    void chat.parsedMessages.value;
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('冲突'))).toHaveLength(0);
+  });
+});

--- a/packages/ai-chat/src/components/AiChat.vue
+++ b/packages/ai-chat/src/components/AiChat.vue
@@ -341,6 +341,17 @@ export interface AiChatProps {
    */
   tree?: ExportedTree;
   /**
+   * 显式声明是否以 `tree` 为权威持久化通道（默认由是否绑定 `v-model:tree` 自动推断）。
+   *
+   * 为真时：`messages` 只作只读镜像输出、不再反向导入内部树（两条桥接同时回写会让 messages
+   * model 被 prop 回灌成 `[]`，进而清空整棵树）。
+   *
+   * 自动推断读的是编译后的 vnode props（`'onUpdate:tree' in props`），覆盖 `v-model:tree` /
+   * 单向 `:tree` 两种写法，绝大多数场景无需管本 prop。仅当推断不适用时才显式声明——典型是
+   * 用 `h()` / JSX 手写 vnode、或经高阶组件 `v-bind="$attrs"` 中转导致监听器形态不同。
+   */
+  treeMode?: boolean;
+  /**
    * 划词引用/追问（opt-in，默认关闭）。true 开启默认能力；false 关闭；对象按 QuoteConfig 细配并默认视为开启，
    * 与全局 provideAiChatConfig().quote 合并（props 优先）。
    *
@@ -465,6 +476,10 @@ const props = withDefaults(defineProps<AiChatProps>(), {
   quote: undefined,
   // suggestions 同款联合类型含 boolean 的坑，同上显式声明 default:undefined。
   suggestions: undefined,
+  // treeMode 是纯 boolean prop，同款 boolean casting 坑更甚：未传时会被自动转成 false 而非
+  // undefined，导致「未显式声明」被误读为「显式关闭 tree 模式」，把 v-model:tree 的自动推断
+  // 整个短路掉（绑了 tree 也不生效）。显式 default:undefined 关闭该转换。
+  treeMode: undefined,
 });
 const emit = defineEmits<AiChatEmits>();
 const ns = useNamespace('ai-chat');
@@ -806,8 +821,11 @@ if (messagesModel.value.length > 0) {
 // 不再反向导入——否则两条桥接在同一 flush 同时回写父级两个 model，messages model 会被
 // prop 回灌成 []，触发 setMessages([]) 把内部树清空（亦是「同绑即崩」的根因）。
 // 用编译后的 vnode props 探测：v-model:tree 必带 onUpdate:tree 监听，初值为 undefined 也能识别。
+// props.treeMode 显式声明时优先于探测（见其 prop 注释）：探测依赖编译后的 vnode 形态，
+// h()/JSX 手写、经高阶组件 $attrs 中转等场景可能失准，留一个不依赖私有 API 的逃生口。
 const vnodeProps = getCurrentInstance()?.vnode.props;
-const isTreeBound = !!vnodeProps && ('onUpdate:tree' in vnodeProps || 'tree' in vnodeProps);
+const isTreeBound =
+  props.treeMode ?? (!!vnodeProps && ('onUpdate:tree' in vnodeProps || 'tree' in vnodeProps));
 watch(messages, (v) => {
   // toRaw 判等与下方反向 watch 对齐：父侧深响应式仓库回灌的是同一数组的 reactive proxy，
   // 裸 !== 对 proxy 恒真。当前 activePath 每次重算都产出新数组，此守卫两种写法结果相同，
@@ -932,6 +950,12 @@ const actionsFor = (item: ChatMessage): ActionsItems | null => {
     const r = a(item);
     return r && r.length > 0 ? r : null;
   }
+  // 1→N 拆分：默认操作条仅末子气泡显示。必须在角色分支**之前**判定，对所有角色一致
+  // （与 branchMap 同规则）——此前只放在下方 AI 分支里，user 消息被 parser 拆分时每个子气泡
+  // 都会拿到 edit 按钮，而 useChat.onEdit 按 resolveParentId 解析回父消息后语义是「把父消息
+  // 的全部 text 块合并改写为单块」，于是用非首个子气泡进入编辑再保存会静默丢掉其余段落。
+  const sub = item.extra?.__sub as SubBubbleMeta | undefined;
+  if (sub && sub.index < sub.count - 1) return null;
   if (item.role === 'user') {
     // 固定默认值（不含 delete），不受 props.actions 数组内容影响（数组形态历史语义只配置 AI 消息）；
     // isLoading 时收窄为 [copy]——原本气泡自带铅笔按钮在全局 loading 时整个不渲染
@@ -941,9 +965,6 @@ const actionsFor = (item: ChatMessage): ActionsItems | null => {
   // abort（用户手动停止）与 success 复用同一套操作条：停止后仍可复制/重新生成/点赞点踩/朗读/引用，
   // 并按需追加 'continue'（见下）；error 态走 Bubble.vue 独立的内联重试条，不受本函数影响。
   if (item.role !== 'ai' || (item.status !== 'success' && item.status !== 'abort')) return null;
-  // 1→N 拆分：默认操作条仅末子气泡显示
-  const sub = item.extra?.__sub as SubBubbleMeta | undefined;
-  if (sub && sub.index < sub.count - 1) return null;
   const base: ActionsItems = a.length > 0 ? [...a] : [];
   // quote 启用且未被业务显式声明时自动注入（策略 A）；函数形态不自动注入（与 speak 同规则）
   if (resolvedQuote.value.enable && resolvedQuote.value.pcQuoteAction && !base.includes('quote')) {

--- a/packages/ai-chat/src/components/blocks/ToolUseBlock.vue
+++ b/packages/ai-chat/src/components/blocks/ToolUseBlock.vue
@@ -1,13 +1,24 @@
 <template>
+  <!-- 委托自定义工具渲染器。除五个契约 prop 外还须透传 $attrs 与块插槽，否则 toolRenderers
+       比 blockRenderers 少两条通道（Bubble 是把 @typing-complete / @keep-mounted-change 与
+       块插槽直接挂在「块渲染器」上的，对 tool_use 而言那个组件是本组件而非委托目标）：
+       本组件 inheritAttrs:false，不显式 v-bind 就等于把这些监听器整个吃掉——自定义工具卡里
+       的 Teleport 浮层（同内置 ImageBlock 的图片预览）因此拿不到 keepMounted，虚拟列表回收
+       宿主行时会连同打开状态一起销毁。 -->
   <component
     :is="delegate"
     v-if="delegate"
+    v-bind="$attrs"
     :block="block"
     :info="info"
     :typing="typing"
     :on-block-action="onBlockAction"
     :on-block-intent="onBlockIntent"
-  />
+  >
+    <template v-for="name in slotNames" :key="name" #[name]="sp">
+      <slot :name="name" v-bind="sp" />
+    </template>
+  </component>
   <div v-else :class="ns.b()">
     <button type="button" :class="ns.e('header')" @click="expanded = !expanded">
       <span :class="ns.e('name')">{{ block.toolName || 'Tool' }}</span>
@@ -56,7 +67,7 @@ export interface ToolUseBlockProps {
 
 <script setup lang="ts">
 import { useNamespace, useLocale } from '@aix/hooks';
-import { computed, ref, type Component } from 'vue';
+import { computed, ref, useSlots, type Component } from 'vue';
 import { locale } from '../../locale';
 import type {
   ContentBlock,
@@ -74,6 +85,10 @@ const props = defineProps<ToolUseBlockProps>();
 
 const ns = useNamespace('tool-use');
 const { t } = useLocale(locale);
+const slots = useSlots();
+// 本组件自身不消费任何具名插槽（默认卡片是纯数据渲染），故收到的全部插槽都属于「块插槽穿透」
+// 链路（AiChat → BubbleList → Bubble → 块渲染器），原样转交委托目标。
+const slotNames = computed(() => Object.keys(slots));
 const expanded = ref(true);
 // toolName 来自不可信流数据，用 Object.hasOwn 做自有属性校验，避免 'constructor'/'toString'
 // 等原型链上的键命中被误当渲染器（__proto__ 本就不在自有属性中，hasOwn 一并挡住）

--- a/packages/ai-chat/src/composables/useChat.ts
+++ b/packages/ai-chat/src/composables/useChat.ts
@@ -324,16 +324,36 @@ export function useChat(options: UseChatOptions): UseChatReturn {
           return entry.bubbles.value;
         };
 
+        // 已告警过的碰撞 id：本 computed 会随流式反复求值，逐次告警会刷屏
+        const warnedCollisions = new Set<string>();
+
         return computed(() => {
           const list: ChatMessage[] = [];
           const map = new Map<string, string>();
+          // 先收齐全部真实消息 id 再遍历：碰撞检测要看的是「派生 id 是否撞上**任意**一条真实
+          // 消息」，边遍历边填的集合只覆盖到当前下标之前，漏判后半段。
           const alive = new Set<string>();
+          for (const m of messages.value) alive.add(m.id);
           messages.value.forEach((m, i) => {
-            alive.add(m.id);
             for (const bubble of bubblesOf(m, i)) {
               // 1→1 与 1→N 的首个子气泡都复用父 id（回写直接命中 SSOT，无需记映射）；
               // 其余派生 id 记入映射，供 resolveParentId 解析回父消息。
-              if (bubble.id !== m.id) map.set(bubble.id, m.id);
+              if (bubble.id !== m.id) {
+                // 派生 id（`${父id}__${序号}`）撞上一条真实消息 id：内置 genMsgId 产出
+                // `msg-<ts>-<n>` 不可能撞，但 defaultMessages / importTree 吃的是外部数据，
+                // 其中完全可能存在名为 `u1__1` 的消息。撞上时 parsedMessages 会出现重复 id
+                // （v-for key 冲突），且 resolveParentId 会把那条真实消息的回写 / 重生成 /
+                // 分支切换全部错误地解析到 `u1` 上——全程无报错，极难排查，故显式告警。
+                if (alive.has(bubble.id) && !warnedCollisions.has(bubble.id)) {
+                  warnedCollisions.add(bubble.id);
+                  devWarn(
+                    `[ai-chat] parser 1→N 的派生气泡 id "${bubble.id}" 与一条真实消息 id 冲突，` +
+                      '该消息的块回写 / 重新生成 / 分支切换会被错误解析到父消息 ' +
+                      `"${m.id}" 上。请避免使用形如 \`<其它消息id>__<数字>\` 的消息 id。`,
+                  );
+                }
+                map.set(bubble.id, m.id);
+              }
               list.push(bubble);
             }
           });
@@ -692,6 +712,19 @@ export function useChat(options: UseChatOptions): UseChatReturn {
     // 各守卫拒绝路径返回 false（未受理、消息零改动），供上层跳过对外透出
     if (isLoading.value) return false;
     const pid = resolveParentId(id);
+    // 守卫：只接受 SSOT 消息 id，不接受 parser 1→N 的**非首个**派生气泡 id。
+    // 下方改写语义是「把父消息的全部 text 块合并为单个 text 块」，而派生气泡只持有父消息的
+    // 一个切片；用它的草稿去改写父消息会静默丢掉其余段落（编辑第 2 段 → 第 1 段消失）。
+    // 首个子气泡复用父 id（pid === id），照常放行；1→1 与无 parser 场景不受影响。
+    // AiChat 侧已按 __sub 只给末子气泡挂操作条，但命令式调用（chatRef.onEdit）绕得过 UI，
+    // 故不变量收在这里而非上层。
+    if (pid !== id) {
+      devWarn(
+        `[ai-chat] onEdit 收到派生气泡 id "${id}"（parser 1→N 拆分产物），已拒绝：` +
+          `编辑须以 SSOT 消息 id "${pid}" 发起，否则父消息的其余文本块会被静默丢弃。`,
+      );
+      return false;
+    }
     const node = tree.getMessage(pid);
     if (!node) return false;
     // 守卫：仅用户消息可编辑重发，避免误改 AI 回复内容


### PR DESCRIPTION
## 背景

对 `packages/ai-chat/src` 做完整审查时发现的三个**静默失效 / 静默丢数据**问题（全程无报错，是最难排查的形态）。每个问题都先写探针复现、再改代码、再验证「移除修复即失败」。

## 修了什么

### ① `toolRenderers` 委托丢事件与插槽通道

`Bubble` 把 `@typing-complete` / `@keep-mounted-change` 与块插槽直接挂在「块渲染器」上；对 `tool_use` 而言那个组件是内置 `ToolUseBlock` 而非委托目标，而它 `inheritAttrs: false` 又没有 `v-bind="$attrs"`，等于把这两条通道整个吃掉。

修复前实测（同一个组件，只换注册通道）：

```
TOOL renderer  -> null                                  ← 事件被吞
BLOCK renderer -> [[{"messageKey":"m1","active":true}]]  ← 正常到达
```

**影响**：自定义工具卡里的 Teleport 浮层（同内置 `ImageBlock` 的图片预览）拿不到 `keepMounted`，虚拟列表回收宿主行时会连同打开状态一起销毁。块插槽穿透同理不可用。

**改动**：`ToolUseBlock` 委托处补 `v-bind="$attrs"` + slot 转发，使两张注册表能力对等。

### ② 1→N 拆分的用户消息编辑会静默丢段落

「仅末子气泡显示操作条」的 `__sub` 去重此前只写在 AI 分支里，user 分支先一步 `return`，于是被 `parser` 拆分的用户消息**每个**子气泡都挂编辑按钮。而 `useChat.onEdit` 按 `resolveParentId` 解析回父消息后语义是「把父消息的全部 text 块合并为单块」——用非首个子气泡编辑再保存，其余段落静默消失，且返回 `true` 让上层照常 emit `edit` 误导业务持久化。

修复前实测：

```
PARSED IDS -> ["u1","u1__1"]
BEFORE     -> ["第一段","第二段"]
ACCEPTED   -> true via id u1__1
AFTER      -> [["user",["第二段改"]],["ai",[]]]   ← "第一段" 消失
```

**改动**（两层，UI 层去入口 + 数据层立不变量）：
- `AiChat.actionsFor`：`__sub` 去重上提到角色判断之前，对所有角色一致（与 `branchMap` 同规则）；
- `useChat.onEdit`：加派生 id 守卫（`pid !== id` 即拒绝 + devWarn）。命令式调用 `chatRef.onEdit()` 绕得过 UI，不变量必须收在 `useChat`。

### ③ 派生 id 与真实消息 id 冲突无提示

内置 `genMsgId` 产出 `msg-<ts>-<n>` 不会撞，但 `defaultMessages` / `importTree` 吃的是外部数据，其中完全可能存在名为 `u1__1` 的消息。撞上时 `parsedMessages` 出现重复 id（v-for key 冲突），且该消息的块回写 / 重生成 / 分支切换全部被错误解析到父消息上。加开发期告警（每个 id 一次）。

## 附带

`AiChat` 新增 `treeMode?: boolean`，作为 `isTreeBound` 自动推断（读编译后 vnode props，属私有 API）的显式逃生口——`h()` / JSX 手写、经高阶组件 `$attrs` 中转时推断会失准。默认行为不变。

注意它是纯 boolean prop，必须显式 `default: undefined` 关闭 Vue 的 boolean casting，否则未传时会被转成 `false`、把自动推断整个短路掉（与 `quote` / `ImagePreview.open` 同款坑，代码里已注明）。

## 验证

| 检查 | 结果 |
|---|---|
| `vitest --run` | **1510 / 1510 通过**（新增 14 个用例） |
| 新增用例「移除修复即失败」 | 已逐个验证：7 个守卫用例在 revert src 后失败，7 个对照用例两态皆通过 |
| `vue-tsc --noEmit` | 通过 |
| `eslint --max-warnings 0` | 通过 |
| `stylelint --max-warnings 0` | 通过 |
| `cspell` | 0 issues |

## 兼容性

无 breaking change。①③ 是纯增量；② 收紧的是一条本就会丢数据的路径；`treeMode` 未传时行为与此前完全一致。

🤖 Generated with AI